### PR TITLE
Draft: [nip] Update examples to use a primitive key value large-objects.mdx

### DIFF
--- a/docs/recipes/large-objects.mdx
+++ b/docs/recipes/large-objects.mdx
@@ -78,8 +78,8 @@ const People = () => {
   const [peopleAtoms] = useAtom(peopleAtomsAtom)
   return (
     <div>
-      {peopleAtoms.map((personAtom) => (
-        <Person personAtom={personAtom} key={`${personAtom}`} />
+      {peopleAtoms.map((personAtom, index) => (
+        <Person key={index} personAtom={personAtom} />
       ))}
     </div>
   )
@@ -112,8 +112,8 @@ const Tags = () => {
   const [tagAtoms] = useAtom(tagsAtomsAtom)
   return (
     <div>
-      {tagAtoms.map((tagAtom) => (
-        <Tag key={`${tagAtom}`} tagAtom={tagAtom} />
+      {tagAtoms.map((tagAtom, index) => (
+        <Tag key={index} tagAtom={tagAtom} />
       ))}
     </div>
   )


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

While reading through I noticed a small drawback, using entire objects as keys is inefficient and more expensive. If there is no meaningful primitive unique value available, it's better to use the map index argument instead  [read more here](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key). This update improves the exmple by addressing this issue.

Just something I noticed while reading through the docs, and stumbled my way here in the recipes section.

## Check List

- [ ] `pnpm run prettier` for formatting code and docs
